### PR TITLE
Add extra ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ typings/
 
 # next.js build output
 .next
+
+# Composer
+vendor
+
+# OSX files
+.DS_Store


### PR DESCRIPTION
* Ignoring composer vendor folder will allow us to do automated code quality checks.
* Ignoring .DS_Store will make the lives of people on OSX a little easier when working on this plugin